### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
 	"name": "mikedance/wp-cli-favorite-plugins",
 	"description": "WP-CLI command to grab favorited plugins from any wordpress.org account.",
+	"type": "wp-cli-package",
 	"homepage": "https://github.com/mikedance/wp-cli-favorite-plugins",
 	"authors":[
 		{


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
